### PR TITLE
Add default speech library config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ env/
 memory.db
 flow_progress.json
 speech_library.json
+!config/speech_library.json
 tenant_map.json
 
 # Test and temp files

--- a/config/speech_library.json
+++ b/config/speech_library.json
@@ -1,0 +1,3 @@
+{
+  "training_data": []
+}

--- a/main.py
+++ b/main.py
@@ -682,8 +682,11 @@ def ensure_required_files():
     for file in required_files:
         file_path = os.path.join("config", file)
         if not os.path.exists(file_path):
-            with open(file_path, "w") as f:
-                f.write("{}")
+            with open(file_path, "w", encoding="utf-8") as f:
+                if file == "speech_library.json":
+                    json.dump({"training_data": []}, f, indent=2)
+                else:
+                    f.write("{}")
             logger.warning(f"Created placeholder for missing file: {file}")
 
 @lru_cache(maxsize=1)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -64,7 +64,15 @@ def _rebuild_tables(data: dict) -> None:
 def _load_speech_library_into_tables() -> None:
     """Read speech_library.json (training_data format) on startup."""
     if not SPEECH_LIBRARY_FILE.exists():
-        logger.warning("speech_library.json not found; starting with empty tables")
+        logger.warning("speech_library.json not found; creating default file")
+        try:
+            ensure_config_structure()
+            SPEECH_LIBRARY_FILE.write_text(json.dumps({"training_data": []}, indent=2), encoding="utf-8")
+        except Exception as e:  # noqa: BLE001
+            logger.error("Error creating default speech_library.json: %s", e)
+            return
+        data = {"training_data": []}
+        _rebuild_tables(data)
         return
 
     try:


### PR DESCRIPTION
## Summary
- add initial `config/speech_library.json`
- keep `config/speech_library.json` tracked in git
- create default speech library file at runtime when missing
- ensure startup placeholder includes empty training data list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_6842ab4f62b08327916af87d01c63dcb