### PR TITLE
Fix URL rendering in ChatBubble

### DIFF
--- a/grace_web_ui/src/components/Chat/ChatBubble.jsx
+++ b/grace_web_ui/src/components/Chat/ChatBubble.jsx
@@ -12,7 +12,9 @@ import "./ChatBubble.css";
  *    and render that substring as <img> instead of plain text.
  */
 const ChatBubble = ({ sender, text }) => {
-  const URL_REGEX = /(https?:\/\/\S+\.(?:jpg|jpeg|png|gif))/gi;
+  // Match image URLs and ignore optional Shopify version query like ?v=123
+  const URL_REGEX =
+    /(https?:\/\/\S+?\.(?:jpg|jpeg|png|gif))(?:\?v=\S+)?/gi;
 
   // Split text into lines and handle URLs
   const lines = text.split(/\r?\n/);


### PR DESCRIPTION
## Summary
- update ChatBubble URL regex to ignore Shopify version query

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6842d52e857883278b17ecb1b9a77745