### PR TITLE
Remove console prints from Shopify tool

### DIFF
--- a/stores/shopify_langchain.py
+++ b/stores/shopify_langchain.py
@@ -18,7 +18,3 @@ async def shopify_product_lookup(query: str) -> str:
         logger.exception("Shopify product lookup failed for query '%s': %s", query, exc)
         return "Sorry, I couldn't retrieve live product information."
 
-# Example: Inspecting tool metadata
-print(shopify_product_lookup.name)        # "shopify_product_lookup"
-print(shopify_product_lookup.description) # "Look up price, stock, or availability of a product in the Shopify store."
-print(shopify_product_lookup.args)        # JSON schema of the arguments


### PR DESCRIPTION
## Summary
- eliminate noisy tool metadata print statements in `shopify_langchain.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6842d6bc55d88327b30718def72ec990